### PR TITLE
fix: resolve CI/CD failures and update workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,10 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -104,7 +108,7 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
@@ -49,6 +49,6 @@ jobs:
       run: pnpm build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,4 @@
 export * from './dto';
-export * from './dto/send.dto';
 export * from './crypto';
 export * from './pii';
 export * from './constants';


### PR DESCRIPTION
## Description

This PR fixes the CI/CD failures that were preventing tests from passing.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Fix duplicate exports in shared package causing TypeScript compilation errors
- Update CodeQL action from v2 to v3 (v2 is deprecated as of Jan 2025)
- Add missing permissions to security scan job for SARIF upload
- Remove redundant export that was causing module conflicts

## Testing

- [x] TypeScript compilation now passes locally
- [x] All GitHub Actions workflows updated to latest versions
- [x] Security scan permissions properly configured

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] TypeScript compilation passes

## Additional Notes

These fixes address the specific CI/CD failures:
1. TypeScript errors from duplicate SendRequest/SendResponse exports
2. Deprecated CodeQL v2 action warnings
3. Security scan permission issues

All tests should now pass in CI/CD.